### PR TITLE
Split Incoming to HttpStream and HttpRequest

### DIFF
--- a/src/net/http/incoming.rs
+++ b/src/net/http/incoming.rs
@@ -1,6 +1,7 @@
 //! HTTP incoming stream
 use net::http::HttpListener;
 use net::http::HttpStream;
+use {HttpRequest, HttpRequestBuilder};
 
 use std::io;
 use futures::stream::Stream;
@@ -19,11 +20,16 @@ impl Incoming {
 }
 
 impl Stream for Incoming {
-    type Item = HttpStream;
+    type Item = (HttpStream, HttpRequest);
     type Error = io::Error;
 
     fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
         let (socket, _) = try_ready!(self.inner.tcp.poll_accept());
-        Ok(Async::Ready(Some(HttpStream {})))
+        Ok(Async::Ready(Some((HttpStream{}, HttpRequestBuilder::new()
+                              .version(2.0)
+                              .host("A")
+                              .method("GET")
+                              .path("/")
+                              .build()))))
     }
 }

--- a/src/net/http/listener.rs
+++ b/src/net/http/listener.rs
@@ -38,7 +38,7 @@ mod listner_test {
         let server = listener
             .incoming()
             .map_err(|error| eprintln!("Error: {:?}", error))
-            .for_each(|socket| Ok(()));
+            .for_each(|(http_stream, http_request)| Ok(()));
         let mut rt = Runtime::new().unwrap();
         rt.spawn(server);
         rt.shutdown_now().wait().unwrap();


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements ☑**
- [x] Tests for the changes have been added (for bug fixes / features)
  - Test is some modified.
- [ ] (Option) Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix 🐛, feature 🆕, docs update 📕, ...)
Feature modified


* **What is the current behavior?** (You can also link to an open issue here)
We can get only socket, so library user must read request from it.


* **What is the new behavior (if this is a feature change)?**
We can get both; socket and HTTP-request.

* **Does this PR introduce a breaking change? 💡** (What changes might users need to make in their application due to this PR?)
No yet.


* **Other information**:


